### PR TITLE
gulpfile - включение для copypngjpg наблюдение и за webp

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -83,7 +83,7 @@ const syncserver = () => {
   gulp.watch('source/js/**/*.{js,json}', gulp.series(js, refresh));
   gulp.watch('source/data/**/*.{js,json}', gulp.series(copy, refresh));
   gulp.watch('source/img/**/*.svg', gulp.series(copysvg, sprite, pugToHtml, refresh));
-  gulp.watch('source/img/**/*.{png,jpg}', gulp.series(copypngjpg, pugToHtml, refresh));
+  gulp.watch('source/img/**/*.{png,jpg,webp}', gulp.series(copypngjpg, pugToHtml, refresh));
 
   gulp.watch('source/favicon/**', gulp.series(copy, refresh));
   gulp.watch('source/video/**', gulp.series(copy, refresh));
@@ -102,7 +102,7 @@ const copysvg = () => {
 };
 
 const copypngjpg = () => {
-  return gulp.src('source/img/**/*.{png,jpg}', {base: 'source'})
+  return gulp.src('source/img/**/*.{png,jpg,webp}', {base: 'source'})
       .pipe(gulp.dest('build'));
 };
 


### PR DESCRIPTION
Я в очередной раз делал webp и в очередной раз, чтобы они заработали (попали в build) мне нужно перезапустить проект чтобы сработал gulp.copy который скопирует всю папку img
Будет здорово, если watch, который следит за png и jpg также следил и за webp. Это позволит делать webp и позволит избавиться от лишнего перезапуска проекта.