### PR TITLE
Ошибка в типе данных для .stylelintrc

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -3,7 +3,7 @@
 
   "overrides": [
     {
-      "files": "**/*.scss",
+      "files": ["**/*.scss"],
       "customSyntax": "postcss-scss"
     }
   ],


### PR DESCRIPTION
В настройках линтера некорректный тип,
https://i.imgur.com/J0azq8Y.png
об этом сообщил vscode, да и в доке только примеры с массивом видел https://stylelint.io/user-guide/configure/#overrides